### PR TITLE
Updateconfiguration to use `options.sourcemaps.enabled`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,7 @@ module.exports = {
         this._super.included.apply(this, arguments);
 
         this.options = app.options.minifyJS || {};
-        this.useSourceMaps = !!app.options.sourcemaps;
+        this.useSourceMaps = !!app.options.sourcemaps.enabled;
     },
 
     postprocessTree(type, tree) {


### PR DESCRIPTION
`options.sourcemaps` is always an object, the correct flag to enable/disable is `options.sourcemaps.enabled` (which is set to `false` by default for  production environments).

[See here for confirmation](https://github.com/ember-cli/ember-cli/blob/f953ba765685c01f3c84cc2e6d34061c421f8865/lib/broccoli/ember-app.js#L240-L243).